### PR TITLE
Add tenant id to authority parameter

### DIFF
--- a/parameters.json
+++ b/parameters.json
@@ -1,5 +1,5 @@
 {
-    "authority": "https://login.microsoftonline.com/common",
+    "authority": "https://login.microsoftonline.com/<your tenant id>",
     "client_id": "enter your Application (Client) Id",
     "scope": ["User.Read"],
     "endpoint": "https://graph.microsoft.com/v1.0/me"


### PR DESCRIPTION
Tenant ID is needed in authority parameter to avoid error: "AADSTS50059: No tenant-identifying information found in either the request or implied by any provided credentials. ..."